### PR TITLE
Feat/local ca trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ scopes = ["openid", "profile", "email"]
 #### Optional Settings
 
 - `https_listen`: Port for HTTPS callbacks (default `8080`).
-- `http_listen`: Port for HTTP callbacks (default disabled).
+- `http_listen`: Port for HTTP callbacks (default disabled). Use this with `redirect_uri = "http://localhost:<port>"` if your browser blocks the self-signed HTTPS callback.
 - `persist_tokens`: Whether to save tokens to disk (default `true`).
 
 ###### You may use Thunderbird's OAuth2 client ID/secret for Microsoft accounts, but it's recommended to create your own credentials.
@@ -81,6 +81,15 @@ vygrant server
 ```
 
 The daemon will listen for OAuth2 callbacks and manage the tokens.
+
+#### Trusting the local certificate (one-time)
+
+Vygrant generates a local CA and a `localhost` certificate on first run. To avoid browser warnings for HTTPS callbacks, import and trust the CA certificate once:
+
+- Use the built-in command: `vygrant trust` (add `--system` for system trust where supported).
+- CA certificate path: `~/.vybr/vygrant/certs/vygrant_ca.pem`
+
+If you reinstall on another machine, a new CA is generated and should be trusted again.
 
 ### 3. Authenticate via CLI
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Vygrant generates a local CA and a `localhost` certificate on first run. To avoi
 
 - Use the built-in command: `vygrant trust` (add `--system` for system trust where supported).
 - CA certificate path: `~/.vybr/vygrant/certs/vygrant_ca.pem`
+ - To remove trust later, run: `vygrant untrust` (add `--system` for system trust).
 
 If you reinstall on another machine, a new CA is generated and should be trusted again.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,6 +20,7 @@ persist_tokens = true
 # client_id = "your_client_id"
 # client_secret = "your_client_secret"
 # redirect_uri = "https://localhost:8080"
+# redirect_uri = "http://localhost:8080" # use with http_listen to avoid self-signed TLS warnings
 # scopes = [
 #   "profile",
 #   "name",

--- a/cmd/priv_unix.go
+++ b/cmd/priv_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cmd
+
+import "os"
+
+func isRoot() bool {
+	return os.Geteuid() == 0
+}

--- a/cmd/priv_windows.go
+++ b/cmd/priv_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cmd
+
+func isRoot() bool {
+	return false
+}

--- a/cmd/trust.go
+++ b/cmd/trust.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/vybraan/vygrant/internal/certgen"
+)
+
+var trustCmd = &cobra.Command{
+	Use:   "trust",
+	Short: "Trust vygrant local CA certificate",
+	Long:  "Adds the vygrant local CA certificate to the OS or user trust store.",
+	Run: func(cmd *cobra.Command, args []string) {
+		system, _ := cmd.Flags().GetBool("system")
+		printOnly, _ := cmd.Flags().GetBool("print")
+
+		certPath, err := certgen.EnsureLocalCA()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to ensure local CA: %v\n", err)
+			os.Exit(1)
+		}
+
+		var installErr error
+		switch runtime.GOOS {
+		case "darwin":
+			installErr = trustDarwin(certPath, system, printOnly)
+		case "windows":
+			installErr = trustWindows(certPath, printOnly)
+		default:
+			if system {
+				installErr = trustLinuxSystem(certPath, printOnly)
+			} else {
+				installErr = trustLinuxUser(certPath, printOnly)
+			}
+		}
+
+		if installErr != nil {
+			fmt.Fprintf(os.Stderr, "trust failed: %v\n", installErr)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	trustCmd.Flags().Bool("system", false, "install into system trust store (may require sudo)")
+	trustCmd.Flags().Bool("print", false, "print the commands without running them")
+	rootCmd.AddCommand(trustCmd)
+}
+
+func trustDarwin(certPath string, system bool, printOnly bool) error {
+	keychain := filepath.Join(os.Getenv("HOME"), "Library/Keychains/login.keychain-db")
+	if system {
+		keychain = "/Library/Keychains/System.keychain"
+	}
+	args := []string{"add-trusted-cert", "-d", "-r", "trustRoot", "-k", keychain, certPath}
+	if printOnly {
+		return printCommand("security", args...)
+	}
+	if system {
+		return runWithSudoIfNeeded("security", args...)
+	}
+	return runCmd("security", args...)
+}
+
+func trustWindows(certPath string, printOnly bool) error {
+	args := []string{"-user", "-addstore", "Root", certPath}
+	if printOnly {
+		return printCommand("certutil", args...)
+	}
+	return runCmd("certutil", args...)
+}
+
+func trustLinuxUser(certPath string, printOnly bool) error {
+	if !hasCommand("certutil") && !printOnly {
+		return fmt.Errorf("certutil not found; try --system or install nss tools")
+	}
+
+	home := os.Getenv("HOME")
+	nssDir := filepath.Join(home, ".pki", "nssdb")
+	dbPath := "sql:" + nssDir
+	if printOnly {
+		if _, err := os.Stat(filepath.Join(nssDir, "cert9.db")); os.IsNotExist(err) {
+			if err := printCommand("certutil", "-d", dbPath, "-N", "--empty-password"); err != nil {
+				return err
+			}
+		}
+		return printCommand("certutil", "-d", dbPath, "-A", "-n", "vygrant local CA", "-t", "C,,", "-i", certPath)
+	}
+
+	if err := os.MkdirAll(nssDir, 0o700); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(nssDir, "cert9.db")); os.IsNotExist(err) {
+		if err := runCmd("certutil", "-d", dbPath, "-N", "--empty-password"); err != nil {
+			return err
+		}
+	}
+	return runCmd("certutil", "-d", dbPath, "-A", "-n", "vygrant local CA", "-t", "C,,", "-i", certPath)
+}
+
+func trustLinuxSystem(certPath string, printOnly bool) error {
+	if hasCommand("update-ca-certificates") {
+		dest := "/usr/local/share/ca-certificates/vygrant_ca.crt"
+		if printOnly {
+			if err := printCommand("cp", certPath, dest); err != nil {
+				return err
+			}
+			return printCommand("update-ca-certificates")
+		}
+		if err := runWithSudoIfNeeded("cp", certPath, dest); err != nil {
+			return err
+		}
+		return runWithSudoIfNeeded("update-ca-certificates")
+	}
+	if hasCommand("update-ca-trust") {
+		dest := "/etc/pki/ca-trust/source/anchors/vygrant_ca.crt"
+		if printOnly {
+			if err := printCommand("cp", certPath, dest); err != nil {
+				return err
+			}
+			return printCommand("update-ca-trust", "extract")
+		}
+		if err := runWithSudoIfNeeded("cp", certPath, dest); err != nil {
+			return err
+		}
+		return runWithSudoIfNeeded("update-ca-trust", "extract")
+	}
+	return fmt.Errorf("no system trust tool found; install ca-certificates tools or use --print")
+}
+
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runWithSudoIfNeeded(name string, args ...string) error {
+	if runtime.GOOS == "windows" || isRoot() {
+		return runCmd(name, args...)
+	}
+	if !hasCommand("sudo") {
+		return fmt.Errorf("sudo not available; rerun with root permissions")
+	}
+	return runCmd("sudo", append([]string{name}, args...)...)
+}
+
+func hasCommand(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func printCommand(name string, args ...string) error {
+	fmt.Printf("%s %s\n", name, strings.Join(args, " "))
+	return nil
+}

--- a/cmd/untrust.go
+++ b/cmd/untrust.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+const trustCertName = "vygrant local CA"
+
+var untrustCmd = &cobra.Command{
+	Use:   "untrust",
+	Short: "Remove vygrant local CA certificate trust",
+	Long:  "Removes the vygrant local CA certificate from the OS or user trust store.",
+	Run: func(cmd *cobra.Command, args []string) {
+		system, _ := cmd.Flags().GetBool("system")
+		printOnly, _ := cmd.Flags().GetBool("print")
+
+		var err error
+		switch runtime.GOOS {
+		case "darwin":
+			err = untrustDarwin(system, printOnly)
+		case "windows":
+			err = untrustWindows(printOnly)
+		default:
+			if system {
+				err = untrustLinuxSystem(printOnly)
+			} else {
+				err = untrustLinuxUser(printOnly)
+			}
+		}
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "untrust failed: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	untrustCmd.Flags().Bool("system", false, "remove from system trust store (may require sudo)")
+	untrustCmd.Flags().Bool("print", false, "print the commands without running them")
+	rootCmd.AddCommand(untrustCmd)
+}
+
+func untrustDarwin(system bool, printOnly bool) error {
+	keychain := filepath.Join(os.Getenv("HOME"), "Library/Keychains/login.keychain-db")
+	if system {
+		keychain = "/Library/Keychains/System.keychain"
+	}
+	args := []string{"delete-certificate", "-c", trustCertName, keychain}
+	if printOnly {
+		return printCommand("security", args...)
+	}
+	if system {
+		return runWithSudoIfNeeded("security", args...)
+	}
+	return runCmd("security", args...)
+}
+
+func untrustWindows(printOnly bool) error {
+	args := []string{"-user", "-delstore", "Root", trustCertName}
+	if printOnly {
+		return printCommand("certutil", args...)
+	}
+	return runCmd("certutil", args...)
+}
+
+func untrustLinuxUser(printOnly bool) error {
+	if !hasCommand("certutil") && !printOnly {
+		return fmt.Errorf("certutil not found; try --system or install nss tools")
+	}
+
+	home := os.Getenv("HOME")
+	nssDir := filepath.Join(home, ".pki", "nssdb")
+	dbPath := "sql:" + nssDir
+	if printOnly {
+		return printCommand("certutil", "-d", dbPath, "-D", "-n", trustCertName)
+	}
+	return runCmd("certutil", "-d", dbPath, "-D", "-n", trustCertName)
+}
+
+func untrustLinuxSystem(printOnly bool) error {
+	if hasCommand("update-ca-certificates") {
+		dest := "/usr/local/share/ca-certificates/vygrant_ca.crt"
+		if printOnly {
+			if err := printCommand("rm", "-f", dest); err != nil {
+				return err
+			}
+			return printCommand("update-ca-certificates")
+		}
+		if err := runWithSudoIfNeeded("rm", "-f", dest); err != nil {
+			return err
+		}
+		return runWithSudoIfNeeded("update-ca-certificates")
+	}
+	if hasCommand("update-ca-trust") {
+		dest := "/etc/pki/ca-trust/source/anchors/vygrant_ca.crt"
+		if printOnly {
+			if err := printCommand("rm", "-f", dest); err != nil {
+				return err
+			}
+			return printCommand("update-ca-trust", "extract")
+		}
+		if err := runWithSudoIfNeeded("rm", "-f", dest); err != nil {
+			return err
+		}
+		return runWithSudoIfNeeded("update-ca-trust", "extract")
+	}
+	return fmt.Errorf("no system trust tool found; install ca-certificates tools or use --print")
+}

--- a/internal/certgen/certgen.go
+++ b/internal/certgen/certgen.go
@@ -9,51 +9,43 @@ import (
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
 
 func GenerateSelfSignedCert() (tls.Certificate, string, error) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return tls.Certificate{}, "", err
 	}
 
-	// Generate public key bytes in uncompressed format (0x04 | X | Y)
-	pubkey := append([]byte{0x04}, priv.PublicKey.X.Bytes()...)
-	pubkey = append(pubkey, priv.PublicKey.Y.Bytes()...)
-	pubKeyHex := FormatPublicKey(pubkey)
-
-	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			CommonName: "localhost",
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // valid for 1 year
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
+	certDir := filepath.Join(home, ".vybr", "vygrant", "certs")
+	if err := os.MkdirAll(certDir, 0o700); err != nil {
+		return tls.Certificate{}, "", err
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	caCertPath := filepath.Join(certDir, "vygrant_ca.pem")
+	caKeyPath := filepath.Join(certDir, "vygrant_ca.key")
+	leafCertPath := filepath.Join(certDir, "localhost.pem")
+	leafKeyPath := filepath.Join(certDir, "localhost.key")
+
+	caCert, caKey, err := ensureCA(caCertPath, caKeyPath)
 	if err != nil {
 		return tls.Certificate{}, "", err
 	}
 
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	privBytes, _ := x509.MarshalECPrivateKey(priv)
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes})
-
-	// Load into tls.Certificate
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	leafCert, leafKey, err := ensureLeaf(leafCertPath, leafKeyPath, caCert, caKey)
 	if err != nil {
 		return tls.Certificate{}, "", err
 	}
 
-	return cert, pubKeyHex, nil
+	pubKeyHex := FormatPublicKeyFromKey(leafKey)
+	return leafCert, pubKeyHex, nil
 }
 
 // formatPublicKey formats the public key into colon-separated uppercase hex
@@ -64,4 +56,210 @@ func FormatPublicKey(b []byte) string {
 		parts = append(parts, strings.ToUpper(hexStr[i:i+2]))
 	}
 	return strings.Join(parts, ":")
+}
+
+func FormatPublicKeyFromKey(priv *ecdsa.PrivateKey) string {
+	// Generate public key bytes in uncompressed format (0x04 | X | Y)
+	pubkey := append([]byte{0x04}, priv.PublicKey.X.Bytes()...)
+	pubkey = append(pubkey, priv.PublicKey.Y.Bytes()...)
+	return FormatPublicKey(pubkey)
+}
+
+func ensureCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	cert, key, err := loadCertAndKey(certPath, keyPath)
+	if err == nil && cert.IsCA {
+		return cert, key, nil
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "vygrant local CA",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyBytes, _ := x509.MarshalECPrivateKey(priv)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	if err := writeFile(certPath, certPEM, 0o644); err != nil {
+		return nil, nil, err
+	}
+	if err := writeFile(keyPath, keyPEM, 0o600); err != nil {
+		return nil, nil, err
+	}
+
+	parsed, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return parsed, priv, nil
+}
+
+func ensureLeaf(certPath, keyPath string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) (tls.Certificate, *ecdsa.PrivateKey, error) {
+	const renewWindow = 30 * 24 * time.Hour
+	certPEM, keyPEM, err := loadPEMFiles(certPath, keyPath)
+	if err == nil {
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err == nil {
+			leaf, err := loadFirstCert(certPEM)
+			if err == nil && leaf.NotAfter.After(time.Now().Add(renewWindow)) && hasLocalhostSANs(leaf) {
+				priv, err := loadECPrivateKeyFromPEM(keyPEM)
+				if err == nil {
+					return cert, priv, nil
+				}
+			}
+		}
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyBytes, _ := x509.MarshalECPrivateKey(priv)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	if err := writeFile(certPath, certPEM, 0o644); err != nil {
+		return tls.Certificate{}, nil, err
+	}
+	if err := writeFile(keyPath, keyPEM, 0o600); err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+	return cert, priv, nil
+}
+
+func loadCertAndKey(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEM, keyPEM, err := loadPEMFiles(certPath, keyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := loadFirstCert(certPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	key, err := loadECPrivateKeyFromPEM(keyPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+func loadPEMFiles(certPath, keyPath string) ([]byte, []byte, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return certPEM, keyPEM, nil
+}
+
+func loadFirstCert(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("invalid cert pem")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func loadECPrivateKeyFromPEM(keyPEM []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil || block.Type != "EC PRIVATE KEY" {
+		return nil, errors.New("invalid key pem")
+	}
+	return x509.ParseECPrivateKey(block.Bytes)
+}
+
+func hasLocalhostSANs(cert *x509.Certificate) bool {
+	hasDNS := false
+	for _, name := range cert.DNSNames {
+		if strings.EqualFold(name, "localhost") {
+			hasDNS = true
+			break
+		}
+	}
+	hasV4 := false
+	hasV6 := false
+	for _, ip := range cert.IPAddresses {
+		if ip.Equal(net.ParseIP("127.0.0.1")) {
+			hasV4 = true
+		}
+		if ip.Equal(net.ParseIP("::1")) {
+			hasV6 = true
+		}
+	}
+	return hasDNS && hasV4 && hasV6
+}
+
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	if err := os.WriteFile(path, data, perm); err != nil {
+		return err
+	}
+	return nil
+}
+
+func EnsureLocalCA() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	certDir := filepath.Join(home, ".vybr", "vygrant", "certs")
+	if err := os.MkdirAll(certDir, 0o700); err != nil {
+		return "", err
+	}
+
+	caCertPath := filepath.Join(certDir, "vygrant_ca.pem")
+	caKeyPath := filepath.Join(certDir, "vygrant_ca.key")
+	if _, _, err := ensureCA(caCertPath, caKeyPath); err != nil {
+		return "", err
+	}
+
+	return caCertPath, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `trust` and `untrust` commands to manage the local CA certificate across macOS, Windows, and Linux.
  * Added support for conditional HTTP and HTTPS listener configuration.

* **Documentation**
  * Added instructions for trusting the locally generated CA certificate (one-time setup).
  * Expanded HTTP configuration guidance with redirect URI examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->