### PR TITLE
feat(daemon): make unix socket path portable 

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -8,10 +8,10 @@ import (
 	"github.com/vybraan/vygrant/internal/storage"
 )
 
-func Router(tokenStore *storage.TokenStore) http.Handler {
+func Router(tokenStore *storage.TokenStore, httpClient *http.Client) http.Handler {
 	r := chi.NewRouter()
 
-	r.Get("/", auth.HandleOAuthCallback(*tokenStore))
+	r.Get("/", auth.HandleOAuthCallback(*tokenStore, httpClient))
 	r.Get("/auth", auth.StartAuthFlow)
 
 	return r

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -155,7 +155,7 @@ func writeErrorPage(w http.ResponseWriter, status int, message string) {
 	fmt.Fprintf(w, errorHTML, message)
 }
 
-func HandleOAuthCallback(tokenStore storage.TokenStore) http.HandlerFunc {
+func HandleOAuthCallback(tokenStore storage.TokenStore, httpClient *http.Client) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
@@ -172,9 +172,13 @@ func HandleOAuthCallback(tokenStore storage.TokenStore) http.HandlerFunc {
 			return
 		}
 		oauthCfg := config.GetOAuth2Config(acct)
+		ctx := context.Background()
+		if httpClient != nil {
+			ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+		}
 
 		code := r.URL.Query().Get("code")
-		token, err := oauthCfg.Exchange(context.Background(), code)
+		token, err := oauthCfg.Exchange(ctx, code)
 		if err != nil {
 
 			writeErrorPage(w, http.StatusInternalServerError, "failed to exchange token. Please try again.")

--- a/internal/client/daemon_client.go
+++ b/internal/client/daemon_client.go
@@ -10,7 +10,7 @@ import (
 
 func SendCommand(command string) (string, error) {
 
-	conn, err := net.Dial("unix", daemon.SOCK)
+	conn, err := net.Dial("unix", daemon.SocketPath())
 	if err != nil {
 		return "", fmt.Errorf("failed to connect to daemon: %w", err)
 	}

--- a/internal/daemon/background.go
+++ b/internal/daemon/background.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/vybraan/vygrant/internal/config"
@@ -13,14 +14,14 @@ const (
 	expiryThreshold = 10 * time.Minute
 )
 
-func StartBackgroundTasks(cfg *config.Config, tokenStore storage.TokenStore, stopCh <-chan struct{}) {
+func StartBackgroundTasks(cfg *config.Config, tokenStore storage.TokenStore, httpClient *http.Client, stopCh <-chan struct{}) {
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			checkExpiringTokens(cfg, tokenStore)
+			checkExpiringTokens(cfg, tokenStore, httpClient)
 		case <-stopCh:
 			log.Println("Stopping background tasks...")
 			return

--- a/internal/daemon/commands.go
+++ b/internal/daemon/commands.go
@@ -51,8 +51,8 @@ func (d *Daemon) HandleCommand(conn net.Conn, input string) {
 			publicKey = "disabled"
 		}
 		info := fmt.Sprintf(
-			"Cache directory: %s\nConfig file: %s\nServer running on:\n  HTTP Port: %s\n  HTTPS Port: %s\nHTTPS public key: %s",
-			SOCK,
+			"Socket path: %s\nConfig file: %s\nServer running on:\n  HTTP Port: %s\n  HTTPS Port: %s\nHTTPS public key: %s",
+			SocketPath(),
 			path.Join(home, VYGRANT_CONFIG),
 			d.Config.HTTPListen,
 			d.Config.HTTPSListen,

--- a/internal/daemon/commands.go
+++ b/internal/daemon/commands.go
@@ -76,7 +76,7 @@ func (d *Daemon) HandleCommand(conn net.Conn, input string) {
 
 		// Auto-refresh token if expired
 		if err == nil && token.Expiry.Before(time.Now()) && token.RefreshToken != "" {
-			newToken, err := RefreshToken(account, d.Config, token)
+			newToken, err := RefreshToken(account, d.Config, token, d.HTTPClient)
 			if err != nil {
 
 				Notify("vygrant - auto refresh failed", fmt.Sprintf("Token for '%s' could not be refreshed and has been deleted. Please re-authenticate.", account))
@@ -119,7 +119,7 @@ func (d *Daemon) HandleCommand(conn net.Conn, input string) {
 			return
 		}
 
-		newToken, err := RefreshToken(account, d.Config, token)
+		newToken, err := RefreshToken(account, d.Config, token, d.HTTPClient)
 		if err != nil {
 			writeError(conn, "Failed to refresh token for '%s': %v", account, err)
 			d.TokenStore.Delete(account)

--- a/internal/daemon/socket_unix.go
+++ b/internal/daemon/socket_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const socketName = "vygrant.sock"
+
+func SocketPath() string {
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		if info, err := os.Stat(runtimeDir); err == nil && info.IsDir() {
+			return filepath.Join(runtimeDir, socketName)
+		}
+	}
+
+	runtimeDir := filepath.Join("/run/user", strconv.Itoa(os.Getuid()))
+	if _, err := os.Stat(runtimeDir); err == nil {
+		return filepath.Join(runtimeDir, socketName)
+	}
+
+	return filepath.Join(os.TempDir(), socketName)
+}

--- a/internal/daemon/socket_windows.go
+++ b/internal/daemon/socket_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const socketName = "vygrant.sock"
+
+func SocketPath() string {
+	return filepath.Join(os.TempDir(), socketName)
+}


### PR DESCRIPTION
and prevent stale socket conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon now supports simultaneous TCP (HTTP/HTTPS) and Unix socket listeners.
  * Socket path is determined per platform and shown in daemon info; lifecycle management improved (stale-socket cleanup, collision prevention).
  * Background tasks and OAuth flows can use a configurable HTTP client for token operations and secure TLS handling.

* **Bug Fixes**
  * Improved startup/teardown cleanup for listeners and sockets to reduce stale resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->